### PR TITLE
Upgrade PHPStan to be 1.x version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",
         "overtrue/phplint": "^2.3",
-        "phpstan/phpstan": "0.*",
+        "phpstan/phpstan": "^1",
         "phpunit/phpunit": "^8 || ^9",
         "squizlabs/php_codesniffer": "^3.5"
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,3 +8,4 @@ parameters:
 	ignoreErrors:
 		- '#OpenSSLAsymmetricKey#'
 		- '#OpenSSLCertificate#'
+		- '#Argument of an invalid type mixed supplied for foreach, only iterables are supported.#'


### PR DESCRIPTION
# Changed log

- Upgrading the PHPStan to be `1.x` version.
- Ignoring the `Argument of an invalid type mixed supplied for foreach, only iterables are supported.` message on `phpstan.neon` file.